### PR TITLE
Fire longPress before key was released

### DIFF
--- a/lib/src/mixins.dart
+++ b/lib/src/mixins.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:meta/meta.dart';
 import 'package:streamdeck/streamdeck.dart';
 
@@ -7,12 +9,17 @@ import 'package:streamdeck/streamdeck.dart';
 /// Fires after [keyUp].
 mixin LongPressDetection on StreamDeckPluginAction {
   int? _downTime;
+  Timer? _longPressTimer;
 
   @override
   @mustCallSuper
   void keyDown(KeyDownEvent event) {
     super.keyDown(event);
     _downTime = DateTime.now().millisecondsSinceEpoch;
+    _longPressTimer = Timer(const Duration(seconds: 1), () {
+      _longPressTimer = null;
+      longPress();
+    });
   }
 
   @override
@@ -21,17 +28,17 @@ mixin LongPressDetection on StreamDeckPluginAction {
     super.keyUp(event);
     final downTime = _downTime;
 
-    if (downTime != null &&
-        DateTime.now().millisecondsSinceEpoch - downTime > 1000) {
-      longPress();
-    } else {
-      shortPress();
+    if (downTime != null) {
+      if (_longPressTimer != null) {
+        _longPressTimer?.cancel();
+        shortPress();
+      }
     }
   }
 
   /// Called after a key is released and was held for less than a second.
   void shortPress();
 
-  /// Called after a key is released and was held for more than a second.
+  /// Called after a key was held for more than a second.
   void longPress();
 }


### PR DESCRIPTION
This brings it in line with the `hold` attribute in `touchTap`.